### PR TITLE
Update Log4j2RceApplication.java

### DIFF
--- a/src/main/java/com/kk/log4j2_rce/Log4j2RceApplication.java
+++ b/src/main/java/com/kk/log4j2_rce/Log4j2RceApplication.java
@@ -7,6 +7,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class Log4j2RceApplication {
 
     public static void main(String[] args) {
+        //高版本的jdk默认trustURLCodebase为false不能成功利用JNDI注入,需要设置为true才能复现
+        System.setProperty("com.sun.jndi.ldap.object.trustURLCodebase","true");
         SpringApplication.run(Log4j2RceApplication.class, args);
     }
 


### PR DESCRIPTION
高版本的jdk默认trustURLCodebase为false不能成功利用JNDI注入，需要设置为true才能复现此rce